### PR TITLE
Add set-like / lifecycle API to PrefOrderedSet, PrefStore factory, and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`pref` is a small Python library that persists application preferences to a local
+SQLite database. It exposes two classes (see `pref/pref.py`):
+
+- `Pref` — an `attrs`-based class users subclass to declare typed preference attributes;
+  reads/writes are transparently synced to SQLite on attribute access.
+- `PrefOrderedSet` — stores an ordered set of strings (list semantics, no duplicates).
+
+Both back onto SQLite via `sqlitedict`, and locate their DB file under the OS's
+per-user config dir via `appdirs` (`SQLitePath.get_sqlite_path()`).
+
+## Common commands
+
+The dev workflow assumes a `venv/` created by the scripts below (the `.bat` files
+hardcode `venv\Scripts\...` and activate it). On non-Windows shells, replicate the
+single relevant command rather than running the batch file.
+
+- Create the dev venv: `scripts\make_venv_dev.bat` (uses Python 3.13, installs `requirements-dev.txt`)
+- Run tests: `venv\Scripts\pytest.exe` (set `PYTHONPATH=%CD%` first, as `scripts\coverage.bat` does)
+- Run a single test: `venv\Scripts\pytest.exe test_pref/test_pref_simple.py::test_preferences`
+- Coverage (HTML + XML): `scripts\coverage.bat`
+- Format: `scripts\blackify.bat` — **black with line length 192** (`-l 192`)
+- Lint: `run_flake8.bat` (ignores E402, F401, W503, E203, E501; output to `doc\flake8_report.txt`)
+- Type check: `scripts\run_mypy.bat`
+- Build wheel: `build.bat`
+- Publish to PyPI: `scripts\pypi.bat`
+
+## Architecture notes
+
+The non-obvious parts live in `pref/pref.py`:
+
+- **`_PreferenceMeta` sentinel types** (`_PreferenceMetaStr`, `_PreferenceMetaBool`):
+  these wrap the bookkeeping attributes (`application_name`, `application_author`,
+  `table`, `file_name`, `_pref_init`). The `__setattr__` / `__attrs_post_init__` logic
+  uses `isinstance(value, _PreferenceMeta)` to decide what *not* to persist — so the
+  config metadata stays out of the DB while the subclass's real preference attributes
+  are written. When adding internal bookkeeping fields, give them a `_PreferenceMeta`
+  type or they will be persisted as preferences.
+
+- **`Pref` sync model**: `__attrs_post_init__` loads existing values from SQLite into
+  the instance; `__setattr__` writes back to SQLite, but only after `_pref_init` is
+  `True` (set at the end of init) and only when the value actually changed. `_pref_init`
+  starts as a class variable and becomes an instance variable once init completes —
+  this guards against DB writes during construction.
+
+- **`PrefOrderedSet` storage trick**: ordering is stored by making the list *string*
+  the SQLite key and its *index* the value, then `get()` returns
+  `sorted(dict, key=dict.get)`. Consequences: duplicates collapse, and non-string
+  inputs come back as strings (see `test_pref/test_pref_simple.py`).
+
+- **Encoding**: both classes pass `encode`/`decode` identity lambdas to `SqliteDict`,
+  so values are stored directly rather than pickled.
+
+- **DB file location**: `get_sqlite_path()` uses `appdirs.user_config_dir(...)`. Default
+  file name is `{application_name}.db`; a custom `file_name` must include an extension
+  (asserted). Tests in `test_pref/conftest.py` delete this directory between runs via an
+  autouse fixture — be aware test runs wipe the `test_pref` app config dir.
+
+## Version
+
+Project metadata lives in `pref/__version__.py` and is consumed by `setup.py`.
+Note `pyproject.toml` carries its own `version` field that can drift from
+`__version__.py` — update both when releasing.

--- a/pref/__init__.py
+++ b/pref/__init__.py
@@ -1,2 +1,2 @@
 from .__version__ import __application_name__, __author__, __version__, __url__, __title__, __description__, __download_url__, __author_email__
-from .pref import Pref, PrefOrderedSet
+from .pref import Pref, PrefOrderedSet, PrefStore, SQLitePath

--- a/pref/__version__.py
+++ b/pref/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 __application_name__ = "pref"
 __title__ = __application_name__
 __author__ = "abel"

--- a/pref/pref.py
+++ b/pref/pref.py
@@ -1,9 +1,13 @@
+import sqlite3
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import appdirs
 from sqlitedict import SqliteDict
 from attr import attrib, attrs
+
+# sentinel used to distinguish "caller passed no default" from "caller passed default=None"
+_UNSET = object()
 
 
 class _PreferenceMeta:
@@ -20,7 +24,11 @@ class _PreferenceMetaBool(_PreferenceMeta, int):
     pass
 
 
-def _to_preferences_meta_str(s: str):
+def _to_preferences_meta_str(s):
+    # None/falsy maps to "" so that the get_sqlite_path() default-file-name logic kicks in
+    # (without this, a None file_name would be converted to the literal string "None")
+    if s is None:
+        s = ""
     return _PreferenceMetaStr(s)
 
 
@@ -39,6 +47,21 @@ class SQLitePath:
         sqlite_path.parent.mkdir(parents=True, exist_ok=True)
         return sqlite_path
 
+    def tables(self) -> List[str]:
+        """
+        :return: the list of table names present in this store's sqlite file
+        """
+        # Note: we deliberately do NOT use SqliteDict.get_tablenames() here. That helper opens a
+        # `with sqlite3.connect(...)` which commits but never closes the connection, leaking a file
+        # handle that blocks deleting the DB on Windows. We open and close the connection ourselves.
+        sqlite_path = self.get_sqlite_path()
+        conn = sqlite3.connect(sqlite_path)
+        try:
+            rows = conn.execute('SELECT name FROM sqlite_master WHERE type="table"').fetchall()
+        finally:
+            conn.close()
+        return [row[0] for row in rows]
+
 
 @attrs
 class Pref(SQLitePath):
@@ -49,7 +72,7 @@ class Pref(SQLitePath):
     application_name = attrib(type=_PreferenceMetaStr, converter=_to_preferences_meta_str)
     application_author = attrib(type=_PreferenceMetaStr, converter=_to_preferences_meta_str)
     table = attrib(default=_PreferenceMetaStr("preferences"), type=_PreferenceMetaStr, converter=_to_preferences_meta_str)
-    file_name = attrib(default=_PreferenceMetaStr(""), type=_PreferenceMetaStr, converter=_to_preferences_meta_str)  # default of "" means use f"{application_name}.db"
+    file_name = attrib(default=None, type=_PreferenceMetaStr, converter=_to_preferences_meta_str)  # default of None/"" means use f"{application_name}.db"
     _pref_init = _PreferenceMetaBool(False)  # starts as a class variable, then set to True as a class instance variable once all initialization is complete
 
     def __attrs_post_init__(self):
@@ -76,6 +99,25 @@ class Pref(SQLitePath):
         sqlite_path = self.get_sqlite_path()
         return SqliteDict(sqlite_path, self.table, autocommit=True, encode=lambda x: x, decode=lambda x: x)
 
+    def reset(self) -> None:
+        """
+        Delete this preference group's table so attributes fall back to their defaults.
+        """
+        sqlite_dict = self.get_sqlite_dict()
+        sqlite_dict.clear()
+        sqlite_dict.commit()
+
+    def close(self) -> None:
+        # Pref opens a fresh autocommit handle per access (see get_sqlite_dict), so there is no
+        # long-lived handle to close. Provided for symmetry with PrefOrderedSet / context-manager use.
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
 
 class PrefOrderedSet(SQLitePath):
     """
@@ -93,9 +135,23 @@ class PrefOrderedSet(SQLitePath):
         # DB stores values directly (not encoded as a pickle)
         self.application_name = application_name
         self.application_author = application_author
+        self.table = table
         self.file_name = file_name
         sqlite_path = self.get_sqlite_path()
         self.sqlite_dict = SqliteDict(sqlite_path, table, encode=lambda x: x, decode=lambda x: x)
+        # companion meta table records whether this set has ever been written, so callers can
+        # tell "never set" apart from "set to empty" (the value table is empty in both cases)
+        self._meta = SqliteDict(sqlite_path, f"{table}__meta", encode=lambda x: x, decode=lambda x: x)
+
+    def _mark_configured(self):
+        self._meta["configured"] = 1
+        self._meta.commit()
+
+    def exists(self) -> bool:
+        """
+        :return: True if this set was ever written (via set()/add()), even if it was set to empty
+        """
+        return self._meta.get("configured") is not None
 
     def set(self, strings: list):
         """
@@ -107,10 +163,81 @@ class PrefOrderedSet(SQLitePath):
         for index, string in enumerate(strings):
             self.sqlite_dict[string] = index
         self.sqlite_dict.commit()  # not using autocommit since we're updating (setting) multiple values in the above for loop
+        self._mark_configured()
 
-    def get(self) -> List[str]:
+    def get(self, default=_UNSET) -> List[str]:
         """
         returns the list of strings
-        :return: list of strings
+        :param default: value to return if this set was never written (only used when explicitly passed)
+        :return: list of strings, or `default` if never written and `default` was provided
         """
+        if not self.exists() and default is not _UNSET:
+            return default
         return list(sorted(self.sqlite_dict, key=self.sqlite_dict.get))
+
+    def add(self, s: str) -> None:
+        """
+        add a single string to the set (no-op if already present); preserves insertion order
+        """
+        if s not in self.sqlite_dict:
+            self.sqlite_dict[s] = len(self.sqlite_dict)  # append at end
+            self.sqlite_dict.commit()
+        self._mark_configured()
+
+    def discard(self, s: str) -> None:
+        """
+        remove a single string from the set (no-op if not present)
+        """
+        if s in self.sqlite_dict:
+            del self.sqlite_dict[s]  # index gaps are fine; get() sorts by the stored index
+            self.sqlite_dict.commit()
+
+    def clear(self) -> None:
+        """
+        remove all strings and reset this set to the "never written" state (exists() becomes False)
+        """
+        self.sqlite_dict.clear()
+        self.sqlite_dict.commit()
+        self._meta.clear()
+        self._meta.commit()
+
+    def close(self) -> None:
+        self.sqlite_dict.close()
+        self._meta.close()
+
+    def __contains__(self, s: str) -> bool:
+        return s in self.sqlite_dict
+
+    def __len__(self) -> int:
+        return len(self.sqlite_dict)
+
+    def __iter__(self):
+        return iter(self.get())
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+class PrefStore:
+    """
+    factory that holds the application identity once so PrefOrderedSet / Pref instances
+    can be created without repeating (application_name, application_author, file_name)
+    """
+
+    def __init__(self, application_name: str, application_author: str, file_name: Optional[str] = None):
+        self.application_name = application_name
+        self.application_author = application_author
+        self.file_name = file_name
+
+    def ordered_set(self, table: str) -> PrefOrderedSet:
+        return PrefOrderedSet(self.application_name, self.application_author, table, self.file_name)
+
+    def bind(self, pref_cls):
+        """
+        construct a Pref subclass bound to this store's identity
+        :param pref_cls: a Pref subclass
+        """
+        return pref_cls(self.application_name, self.application_author, file_name=self.file_name or "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pref"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["abel"]
 description = "persistent preferences store to local sqlite"
 readme = "README.md"

--- a/test_pref/test_pref_close_and_context_manager.py
+++ b/test_pref/test_pref_close_and_context_manager.py
@@ -1,0 +1,30 @@
+from attr import attrib, attrs
+
+from pref import __author__, Pref, PrefOrderedSet
+
+from test_pref import __application_name__
+
+
+@attrs
+class PrefTst(Pref):
+    my_variable = attrib(default=None)
+
+
+def test_ordered_set_context_manager_persists_and_closes():
+    with PrefOrderedSet(__application_name__, __author__, "selection") as s:
+        s.set(["a", "b"])
+    # handle closed; reopening reads the persisted data
+    with PrefOrderedSet(__application_name__, __author__, "selection") as readback:
+        assert readback.get() == ["a", "b"]
+
+
+def test_ordered_set_explicit_close():
+    s = PrefOrderedSet(__application_name__, __author__, "selection")
+    s.add("x")
+    s.close()  # explicit close should not raise
+
+
+def test_pref_context_manager():
+    with PrefTst(__application_name__, __author__) as p:  # close() is a no-op for Pref
+        p.my_variable = "ctx"
+    assert PrefTst(__application_name__, __author__).my_variable == "ctx"

--- a/test_pref/test_pref_file_name_default.py
+++ b/test_pref/test_pref_file_name_default.py
@@ -1,0 +1,17 @@
+from attr import attrib, attrs
+
+from pref import __author__, Pref
+
+from test_pref import __application_name__
+
+
+@attrs
+class PrefTst(Pref):
+    my_variable = attrib(default=None)
+
+
+def test_pref_file_name_defaults_to_app_db():
+    # Pref.file_name defaults to None (converted to ""), matching PrefOrderedSet's default,
+    # so the sqlite file name falls back to f"{application_name}.db".
+    p = PrefTst(__application_name__, __author__)
+    assert p.get_sqlite_path().name == f"{__application_name__}.db"

--- a/test_pref/test_pref_ordered_set_exists.py
+++ b/test_pref/test_pref_ordered_set_exists.py
@@ -1,0 +1,18 @@
+from pref import __author__, PrefOrderedSet
+
+from test_pref import __application_name__
+
+
+def test_exists_distinguishes_unset_from_empty():
+    with PrefOrderedSet(__application_name__, __author__, "selection") as s:
+        # never written
+        assert s.exists() is False
+        assert s.get(default=None) is None
+        assert s.get(default=["fallback"]) == ["fallback"]
+        assert s.get() == []  # no-arg back-compat: empty list, not the default
+
+        # explicitly set to empty
+        s.set([])
+        assert s.exists() is True
+        assert s.get() == []
+        assert s.get(default=["fallback"]) == []  # exists() True -> ignore default

--- a/test_pref/test_pref_ordered_set_mutators.py
+++ b/test_pref/test_pref_ordered_set_mutators.py
@@ -1,0 +1,28 @@
+from pref import __author__, PrefOrderedSet
+
+from test_pref import __application_name__
+
+
+def test_add_discard_and_membership():
+    with PrefOrderedSet(__application_name__, __author__, "selection") as s:
+        s.add("a")
+        s.add("b")
+        s.add("a")  # dedup, no reorder
+        assert s.get() == ["a", "b"]
+        assert "a" in s
+        assert "z" not in s
+        assert len(s) == 2
+        assert list(s) == ["a", "b"]
+
+        s.discard("a")
+        assert "a" not in s
+        assert s.get() == ["b"]
+        s.discard("not-there")  # no-op
+        assert s.get() == ["b"]
+
+
+def test_add_marks_set_as_configured():
+    with PrefOrderedSet(__application_name__, __author__, "selection") as s:
+        assert s.exists() is False
+        s.add("x")
+        assert s.exists() is True

--- a/test_pref/test_pref_store.py
+++ b/test_pref/test_pref_store.py
@@ -1,0 +1,23 @@
+from attr import attrib, attrs
+
+from pref import __author__, Pref, PrefOrderedSet, PrefStore
+
+from test_pref import __application_name__
+
+
+@attrs
+class PrefTst(Pref):
+    my_variable = attrib(default=None)
+
+
+def test_pref_store_factory():
+    store = PrefStore(__application_name__, __author__)
+
+    with store.ordered_set("group_a") as os_a:
+        os_a.set(["one", "two"])
+    with PrefOrderedSet(__application_name__, __author__, "group_a") as readback:
+        assert readback.get() == ["one", "two"]
+
+    pref = store.bind(PrefTst)
+    pref.my_variable = "bound"
+    assert PrefTst(__application_name__, __author__).my_variable == "bound"

--- a/test_pref/test_pref_tables_clear_reset.py
+++ b/test_pref/test_pref_tables_clear_reset.py
@@ -1,0 +1,32 @@
+from attr import attrib, attrs
+
+from pref import __author__, Pref, PrefOrderedSet
+
+from test_pref import __application_name__
+
+
+@attrs
+class PrefTst(Pref):
+    my_variable = attrib(default=None)
+
+
+def test_tables_lists_the_data_table():
+    with PrefOrderedSet(__application_name__, __author__, "houses") as s:
+        s.set(["a", "b"])
+        assert "houses" in s.tables()
+
+
+def test_clear_resets_to_unset():
+    with PrefOrderedSet(__application_name__, __author__, "houses") as s:
+        s.set(["a", "b"])
+        s.clear()
+        assert s.get() == []
+        assert s.exists() is False  # clear() resets to "never written"
+
+
+def test_reset_restores_defaults():
+    pref = PrefTst(__application_name__, __author__)
+    pref.my_variable = "to-be-reset"
+    pref.reset()
+    # a freshly constructed instance falls back to the default
+    assert PrefTst(__application_name__, __author__).my_variable is None


### PR DESCRIPTION
## Summary

Additive, non-breaking extensions to the public API, plus project docs and a version bump to **0.4.0**.

### `PrefOrderedSet`
- `exists()` and `get(default=...)` distinguish "never set" from "set to empty" (via a companion meta table)
- `add()` / `discard()` and `__contains__` / `__len__` / `__iter__` for incremental set mutation
- `clear()` resets the set (including the meta marker)

### Lifecycle
- `close()` and context-manager support on `PrefOrderedSet` and `Pref`, fixing an open-handle leak that blocked deleting the DB on Windows

### `Pref`
- `reset()` drops a preference group so attributes fall back to defaults
- `file_name` now defaults to `None` to match `PrefOrderedSet` (converter maps `None`/falsy → `""`)

### `SQLitePath`
- `tables()` lists the sqlite tables; implemented locally so the connection is closed (`SqliteDict.get_tablenames` leaks a handle on Windows)

### `PrefStore`
- New factory holding the application identity once (`ordered_set()`, `bind()`)

### Housekeeping
- Add `CLAUDE.md`
- Reconcile `pyproject.toml` / `pref/__version__.py` and bump minor version to `0.4.0`

## Testing
- Added 6 functionality-centric test files (one scenario per file, matching repo convention)
- Full suite: **14 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)