### PR TITLE
Add GitHub Actions CI running pytest on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    name: pytest (${{ matrix.os }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: pytest -q

--- a/scripts/make_venv_dev.bat
+++ b/scripts/make_venv_dev.bat
@@ -1,7 +1,7 @@
 pushd .
 cd ..
 rmdir /S /Q venv
-"C:\Program Files\Python313\python.exe" -m venv --clear venv
+"C:\Program Files\Python314\python.exe" -m venv --clear venv
 venv\Scripts\python -m pip install --upgrade pip
 venv\Scripts\python -m pip  install -U setuptools
 venv\Scripts\python -m pip  install -U -r requirements-dev.txt


### PR DESCRIPTION
## Summary

Adds a CI workflow that runs the test suite on every PR (and on pushes to `main`).

- **Triggers**: `pull_request` and `push` to `main`
- **Matrix**: `ubuntu-latest` + `windows-latest` × Python `3.10`–`3.15`
  - `allow-prereleases: true` so 3.14/3.15 alpha/beta interpreters resolve
  - Windows is included intentionally — the open-handle leak fixed in #2 was Windows-specific
- Installs `requirements-dev.txt` and runs `pytest -q` with `PYTHONPATH` set to the repo root (mirrors `coverage.bat`)
- Also bumps the dev venv interpreter in `scripts/make_venv_dev.bat` to Python 3.14

## Note

Bleeding-edge prereleases (esp. 3.15) may lack prebuilt wheels for `sqlitedict`/`attrs`; if a job fails building from source rather than on a real test failure, we can mark those rows `continue-on-error: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)