### PR TITLE
Bump checkout and setup-python action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true


### PR DESCRIPTION
## Summary

Bumps the CI actions to clear the Node.js 20 deprecation warning surfaced by the previous run:

- `actions/checkout@v4` → `@v5`
- `actions/setup-python@v5` → `@v6`

Both major versions run on Node.js 24. CI on this PR serves as the live confirmation that the bumped actions work and the warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)